### PR TITLE
Properly handle object keys containing #'s

### DIFF
--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -137,8 +137,8 @@ def check_status(to_check):
     response = boto3.client('s3').head_object(Bucket=bucket, Key=key)
     path = "s3://" + bucket + "/" + key
     if 'StorageClass' not in response \
-            or response['StorageClass'] != "GLACIER":
-        s_print("Object {} storageClass is not Glacier".format(path))
+            or response['StorageClass'] not in ["GLACIER", "DEEP_ARCHIVE"]:
+        s_print("Object {} storageClass is not Glacier or Glacier Deep Archvie: {}".format(path, response['StorageClass']))
         not_on_glacier_count.inc()
     else:
         if 'Restore' in response:

--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -126,6 +126,8 @@ def restore(to_restore, max_tries=10):
             s_print("Conflicting operation in progress. Retrying in 1 minute")
             time.sleep(60)
             restore(to_restore, max_tries - 1)
+        elif e.response['Error']['Code'] == 'NoSuchKey':
+            s_print("Unable to find S3 object key: {}".format(key))
         else:
             raise e
 
@@ -179,7 +181,7 @@ def restore_main(
     to_restore = []
 
     for url_to_restore, size in s3_urls_and_sizes:
-        url_parsed = urllib.parse.urlparse(url_to_restore)
+        url_parsed = urllib.parse.urlparse(url_to_restore, allow_fragments=False)
         if url_parsed.scheme != "s3":
             raise Exception("Prefix scheme must be s3!")
         to_restore.append(dict(key=url_parsed.path, bucket=url_parsed.netloc, size=size))


### PR DESCRIPTION
Currently if an object key contains a `#` the object keys is split at that location due to use of `urllib.parse()` and anything after the `#` is returned as the `fragment` part of the named tuple returned by `urllib.parse()`. Since the key is no longer a valid S3 object the script fails with a `NoSuchKey` exception.

This PR handles disables splitting the URL at the fragment identifier since it's not used in S3 object keys and handle the `NoSuchKey` exception, printing the error and key to the screen and continuing on with the restoration of the remaining objects.

Example object key: `04. Club House - Light My Fire (# X Club Cut).flac` would come out as `04. Club House - Light My Fire (`

```
Traceback (most recent call last):
  File "/home/shane/.local/bin/aws-s3-glacier-restore", line 331, in <module>
    restore_main(
  File "/home/shane/.local/bin/aws-s3-glacier-restore", line 248, in restore_main
    pool.map(
  File "/home/shane/.pyenv/versions/3.9.1/lib/python3.9/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/home/shane/.pyenv/versions/3.9.1/lib/python3.9/multiprocessing/pool.py", line 771, in get
    raise self._value
  File "/home/shane/.pyenv/versions/3.9.1/lib/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/shane/.pyenv/versions/3.9.1/lib/python3.9/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/home/shane/.local/bin/aws-s3-glacier-restore", line 130, in restore
    raise e
  File "/home/shane/.local/bin/aws-s3-glacier-restore", line 109, in restore
    boto3.client('s3') \
  File "/home/shane/.local/pipx/venvs/aws-s3-glacier-restore/lib/python3.9/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/shane/.local/pipx/venvs/aws-s3-glacier-restore/lib/python3.9/site-packages/botocore/client.py", line 676, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.NoSuchKey: An error occurred (NoSuchKey) when calling the RestoreObject operation: The specified key does not exist
```