### PR TITLE
Fix bugs, drop python 2 compatibility support, add unit tests (v0.0.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,30 @@
+# Virtual environments
 env/
+venv/
+.venv/
+
+# Byte-compiled / optimized
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Testing / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ optional arguments:
                         you'll need restored files. Once you don't need them
                         you can delete them from destination bucket.
   -t THREADS, --threads THREADS
-                        Number of threads to use. Default=40
+                        Number of threads to use. Default=1
+  -n TIER_NR, --tier_nr TIER_NR
+                        Optional parameter to set the tier level for restore (skips interactive prompt). 1=Expedited, 2=Standard, 3=Bulk.
   -s, --status_print    Just print status of files and how many of them are in
                         glacier and how many of them are restored already
   --profile PROFILE     Use a specific AWS profile from your credential file.

--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import argparse
 import sys
 import time
 from multiprocessing.dummy import Pool as ThreadPool
-from six.moves import urllib
+import urllib.parse
 import threading
 import re
 
@@ -218,7 +217,7 @@ def restore_main(
                     "Glacier. For them restore isn't needed"
                     .format(not_on_glacier_count.value()))
         if missing:
-            to_restore = list(filter(lambda x: x != None, not_restored))
+            to_restore = list(filter(lambda x: x is not None, not_restored))
         else:
             return
 
@@ -306,7 +305,6 @@ if __name__ == '__main__':
              'files. Once you don\'t need them you can delete them from '
              'destination bucket.'
     )
-    # 40 threads from Mac (home network) results in 2K files restored per minute
     parser.add_argument(
         '-t',
         '--threads',

--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -142,7 +142,7 @@ def check_status(to_check):
     response = boto3.client('s3').head_object(Bucket=bucket, Key=key)
     path = "s3://" + bucket + "/" + key
     storage_class = response.get('StorageClass', 'STANDARD')
-    if storage_class not in ["GLACIER", "DEEP_ARCHIVE"]:
+    if storage_class not in ["GLACIER", "DEEP_ARCHIVE", "INTELLIGENT_TIERING"]:
         s_print("Object {} storageClass is not Glacier or Glacier Deep Archive:"
                 " {}".format(path, storage_class))
         not_on_glacier_count.inc()

--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -89,53 +89,56 @@ def get_matching_s3_keys_and_sizes(s3_url):
 
 
 def restore(to_restore, max_tries=10):
-    if max_tries < 1:
-        s_print("Maximum number of attempts at restoring the object exceeded")
-        return
     global destination_bucket
     key = to_restore['file']['key'].lstrip('/')
     bucket = to_restore['file']['bucket']
-    s_print("Restoring s3://{}/{}".format(bucket, key))
-    try:
-        if destination_bucket is not None:
-            boto3.client('s3') \
-                .restore_object(
-                Bucket=bucket, Key=key,
-                RestoreRequest={'OutputLocation': {
-                    'S3': {
-                        'BucketName': destination_bucket,
-                        'Prefix': key}},
-                    'GlacierJobParameters': {
-                        'Tier': to_restore['tier']}})
 
-        else:
-            if to_restore['days'] is None:
-                raise ValueError(
-                    "days_to_keep is required when destination_bucket is not set")
-            boto3.client('s3') \
-                .restore_object(
-                Bucket=bucket, Key=key,
-                RestoreRequest={'Days': to_restore['days'],
-                                'GlacierJobParameters': {
-                                    'Tier': to_restore['tier']}})
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'RestoreAlreadyInProgress':
-            s_print("Restore already in progress")
-        elif e.response['Error']['Code'] == 'InvalidObjectState':
-            s_print("Object's storage class is not GLACIER")
-        elif e.response['Error']['Code'] == \
-                'GlacierExpeditedRetrievalNotAvailable':
-            s_print("Expedited retrieval not available. Sleeping for 1 minute")
-            time.sleep(60)
-            restore(to_restore, max_tries - 1)
-        elif e.response['Error']['Code'] == 'OperationAborted':
-            s_print("Conflicting operation in progress. Retrying in 1 minute")
-            time.sleep(60)
-            restore(to_restore, max_tries - 1)
-        elif e.response['Error']['Code'] == 'NoSuchKey':
-            s_print("Unable to find S3 object key: {}".format(key))
-        else:
-            raise e
+    for attempt in range(max_tries):
+        s_print("Restoring s3://{}/{}".format(bucket, key))
+        try:
+            if destination_bucket is not None:
+                boto3.client('s3') \
+                    .restore_object(
+                    Bucket=bucket, Key=key,
+                    RestoreRequest={'OutputLocation': {
+                        'S3': {
+                            'BucketName': destination_bucket,
+                            'Prefix': key}},
+                        'GlacierJobParameters': {
+                            'Tier': to_restore['tier']}})
+
+            else:
+                if to_restore['days'] is None:
+                    raise ValueError(
+                        "days_to_keep is required when destination_bucket is not set")
+                boto3.client('s3') \
+                    .restore_object(
+                    Bucket=bucket, Key=key,
+                    RestoreRequest={'Days': to_restore['days'],
+                                    'GlacierJobParameters': {
+                                        'Tier': to_restore['tier']}})
+            return
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            if error_code == 'RestoreAlreadyInProgress':
+                s_print("Restore already in progress")
+                return
+            elif error_code == 'InvalidObjectState':
+                s_print("Object's storage class is not GLACIER")
+                return
+            elif error_code == 'GlacierExpeditedRetrievalNotAvailable':
+                s_print("Expedited retrieval not available. Sleeping for 1 minute")
+                time.sleep(60)
+            elif error_code == 'OperationAborted':
+                s_print("Conflicting operation in progress. Retrying in 1 minute")
+                time.sleep(60)
+            elif error_code == 'NoSuchKey':
+                s_print("Unable to find S3 object key: {}".format(key))
+                return
+            else:
+                raise e
+
+    s_print("Maximum number of attempts at restoring the object exceeded")
 
 
 def check_status(to_check):

--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -310,9 +310,9 @@ if __name__ == '__main__':
     parser.add_argument(
         '-t',
         '--threads',
-        help='Number of threads to use. Default=40',
+        help='Number of threads to use. Default=1',
         type=int,
-        default=40)
+        default=1)
     # Added an option to add a tier number to the command line. Skips prompt
     parser.add_argument(
         '-n',

--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -109,6 +109,9 @@ def restore(to_restore, max_tries=10):
                         'Tier': to_restore['tier']}})
 
         else:
+            if to_restore['days'] is None:
+                raise ValueError(
+                    "days_to_keep is required when destination_bucket is not set")
             boto3.client('s3') \
                 .restore_object(
                 Bucket=bucket, Key=key,

--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -138,10 +138,10 @@ def check_status(to_check):
     bucket = to_check['file']['bucket']
     response = boto3.client('s3').head_object(Bucket=bucket, Key=key)
     path = "s3://" + bucket + "/" + key
-    if 'StorageClass' not in response \
-            or response['StorageClass'] not in ["GLACIER", "DEEP_ARCHIVE"]:
-        s_print("Object {} storageClass is not Glacier or Glacier Deep Archvie:"
-                " {}".format(path, response['StorageClass']))
+    storage_class = response.get('StorageClass', 'STANDARD')
+    if storage_class not in ["GLACIER", "DEEP_ARCHIVE"]:
+        s_print("Object {} storageClass is not Glacier or Glacier Deep Archive:"
+                " {}".format(path, storage_class))
         not_on_glacier_count.inc()
     else:
         if 'Restore' in response:

--- a/aws-s3-glacier-restore
+++ b/aws-s3-glacier-restore
@@ -12,6 +12,9 @@ import boto3
 from botocore.exceptions import ClientError
 
 destination_bucket = None
+s_print_lock = threading.Lock()
+restored_count = None
+not_on_glacier_count = None
 
 
 def s_print(*a, **b):
@@ -167,6 +170,12 @@ def restore_main(
         status_check,
         missing,
         tier_nr):
+    global restored_count, not_on_glacier_count
+
+    if restored_count is None:
+        restored_count = AtomicInteger()
+    if not_on_glacier_count is None:
+        not_on_glacier_count = AtomicInteger()
 
     pool = ThreadPool(number_of_threads)
 
@@ -262,8 +271,6 @@ def restore_main(
 
 
 if __name__ == '__main__':
-    s_print_lock = threading.Lock()
-
     parser = argparse.ArgumentParser(
         description='Utility script to restore files on AWS S3 that have '
                     'GLACIER storage class')
@@ -324,8 +331,8 @@ if __name__ == '__main__':
     )
 
     args = vars(parser.parse_args())
-    restored_count = AtomicInteger()
-    not_on_glacier_count = AtomicInteger()
+    restored_count = AtomicInteger()  # noqa: F841 - used as module global
+    not_on_glacier_count = AtomicInteger()  # noqa: F841 - used as module global
 
     if args['input_file'] is None and args['prefix'] is None:
         raise Exception("Must either specify input_file or prefix")

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,17 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/marko-bast/aws-s3-glacier-restore",
     packages=setuptools.find_packages(),
+    python_requires='>=3.7',
     classifiers=[
-        # 'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=['requests[security]>=2.18.3',
-                      'six',
+    install_requires=['six',
                       'boto3>=1.9']
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    install_requires=['six',
-                      'boto3>=1.9']
+    install_requires=['boto3>=1.9']
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name='aws-s3-glacier-restore',
-    version='0.0.4',
+    version='0.0.5',
     scripts=['aws-s3-glacier-restore'],
     author="Marko Baštovanović",
     author_email="marko.bast@gmail.com",

--- a/test_glacier_restore.py
+++ b/test_glacier_restore.py
@@ -1,0 +1,317 @@
+"""Unit tests for aws-s3-glacier-restore."""
+import importlib.machinery
+import importlib.util
+import os
+import sys
+import threading
+import pytest
+from unittest.mock import patch, MagicMock
+from botocore.exceptions import ClientError
+
+# Import the module despite its hyphenated name and missing .py extension
+_module_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "aws-s3-glacier-restore")
+_loader = importlib.machinery.SourceFileLoader("glacier_restore", _module_path)
+_spec = importlib.util.spec_from_loader("glacier_restore", _loader)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["glacier_restore"] = mod
+_spec.loader.exec_module(mod)
+
+# Aliases for convenience
+AtomicInteger = mod.AtomicInteger
+get_matching_s3_keys_and_sizes = mod.get_matching_s3_keys_and_sizes
+restore = mod.restore
+check_status = mod.check_status
+
+
+def _make_client_error(code, message="error"):
+    return ClientError(
+        {"Error": {"Code": code, "Message": message}}, "operation_name"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AtomicInteger
+# ---------------------------------------------------------------------------
+class TestAtomicInteger:
+    def test_initial_value(self):
+        ai = AtomicInteger()
+        assert ai.value() == 0
+
+    def test_initial_value_custom(self):
+        ai = AtomicInteger(42)
+        assert ai.value() == 42
+
+    def test_inc_default(self):
+        ai = AtomicInteger()
+        ai.inc()
+        assert ai.value() == 1
+
+    def test_inc_custom(self):
+        ai = AtomicInteger(10)
+        ai.inc(5)
+        assert ai.value() == 15
+
+    def test_thread_safety(self):
+        ai = AtomicInteger()
+        threads = [threading.Thread(target=ai.inc) for _ in range(1000)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert ai.value() == 1000
+
+
+# ---------------------------------------------------------------------------
+# get_matching_s3_keys_and_sizes
+# ---------------------------------------------------------------------------
+class TestGetMatchingS3KeysAndSizes:
+    def test_rejects_non_s3_scheme(self):
+        with pytest.raises(Exception, match="Prefix scheme must be s3"):
+            list(get_matching_s3_keys_and_sizes("http://bucket/prefix"))
+
+    @patch("glacier_restore.boto3")
+    def test_single_page(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "data/file1.txt", "Size": 100},
+                {"Key": "data/file2.txt", "Size": 200},
+            ]
+        }
+        results = list(get_matching_s3_keys_and_sizes("s3://mybucket/data/"))
+        assert results == [
+            ("s3://mybucket/data/file1.txt", 100),
+            ("s3://mybucket/data/file2.txt", 200),
+        ]
+
+    @patch("glacier_restore.boto3")
+    def test_pagination(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.list_objects_v2.side_effect = [
+            {
+                "Contents": [{"Key": "data/a.txt", "Size": 10}],
+                "NextContinuationToken": "token123",
+            },
+            {
+                "Contents": [{"Key": "data/b.txt", "Size": 20}],
+            },
+        ]
+        results = list(get_matching_s3_keys_and_sizes("s3://mybucket/data/"))
+        assert len(results) == 2
+        assert results[1] == ("s3://mybucket/data/b.txt", 20)
+        assert mock_client.list_objects_v2.call_count == 2
+
+    @patch("glacier_restore.boto3")
+    def test_no_contents_raises(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.list_objects_v2.return_value = {}
+        with pytest.raises(Exception, match="No S3 files for prefix"):
+            list(get_matching_s3_keys_and_sizes("s3://mybucket/empty/"))
+
+
+# ---------------------------------------------------------------------------
+# restore
+# ---------------------------------------------------------------------------
+class TestRestore:
+    def _make_to_restore(self, **overrides):
+        base = {
+            "file": {"key": "/data/file.txt", "bucket": "mybucket", "size": 100},
+            "days": 5,
+            "tier": "Standard",
+        }
+        base.update(overrides)
+        return base
+
+    @patch("glacier_restore.boto3")
+    def test_successful_restore(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        restore(self._make_to_restore())
+        mock_client.restore_object.assert_called_once()
+        call_kwargs = mock_client.restore_object.call_args
+        assert call_kwargs[1]["Bucket"] == "mybucket"
+        assert call_kwargs[1]["Key"] == "data/file.txt"
+        assert call_kwargs[1]["RestoreRequest"]["Days"] == 5
+
+    @patch("glacier_restore.boto3")
+    def test_restore_to_destination_bucket(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mod.destination_bucket = "dest-bucket"
+        try:
+            restore(self._make_to_restore())
+            call_kwargs = mock_client.restore_object.call_args[1]
+            assert "OutputLocation" in call_kwargs["RestoreRequest"]
+            assert call_kwargs["RestoreRequest"]["OutputLocation"]["S3"]["BucketName"] == "dest-bucket"
+        finally:
+            mod.destination_bucket = None
+
+    @patch("glacier_restore.boto3")
+    def test_restore_already_in_progress(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.restore_object.side_effect = _make_client_error(
+            "RestoreAlreadyInProgress"
+        )
+        # Should not raise
+        restore(self._make_to_restore())
+
+    @patch("glacier_restore.boto3")
+    def test_invalid_object_state(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.restore_object.side_effect = _make_client_error(
+            "InvalidObjectState"
+        )
+        restore(self._make_to_restore())
+
+    @patch("glacier_restore.boto3")
+    def test_no_such_key(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.restore_object.side_effect = _make_client_error("NoSuchKey")
+        restore(self._make_to_restore())
+
+    @patch("glacier_restore.boto3")
+    def test_unknown_error_is_raised(self, mock_boto3):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.restore_object.side_effect = _make_client_error("SomeOtherError")
+        with pytest.raises(ClientError):
+            restore(self._make_to_restore())
+
+    @patch("glacier_restore.time")
+    @patch("glacier_restore.boto3")
+    def test_operation_aborted_retries(self, mock_boto3, mock_time):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        # Fail twice with OperationAborted, then succeed
+        mock_client.restore_object.side_effect = [
+            _make_client_error("OperationAborted"),
+            _make_client_error("OperationAborted"),
+            None,
+        ]
+        restore(self._make_to_restore(), max_tries=5)
+        assert mock_client.restore_object.call_count == 3
+        assert mock_time.sleep.call_count == 2
+
+    @patch("glacier_restore.time")
+    @patch("glacier_restore.boto3")
+    def test_max_retries_exceeded(self, mock_boto3, mock_time):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.restore_object.side_effect = _make_client_error("OperationAborted")
+        restore(self._make_to_restore(), max_tries=3)
+        assert mock_client.restore_object.call_count == 3
+
+    @patch("glacier_restore.time")
+    @patch("glacier_restore.boto3")
+    def test_expedited_not_available_retries(self, mock_boto3, mock_time):
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.restore_object.side_effect = [
+            _make_client_error("GlacierExpeditedRetrievalNotAvailable"),
+            None,
+        ]
+        restore(self._make_to_restore(), max_tries=5)
+        assert mock_client.restore_object.call_count == 2
+        mock_time.sleep.assert_called_once_with(60)
+
+    def test_days_none_without_destination_bucket(self):
+        mod.destination_bucket = None
+        with pytest.raises(ValueError, match="days_to_keep is required"):
+            restore(self._make_to_restore(days=None))
+
+
+# ---------------------------------------------------------------------------
+# check_status
+# ---------------------------------------------------------------------------
+class TestCheckStatus:
+    def _make_to_check(self):
+        return {"file": {"key": "/data/file.txt", "bucket": "mybucket", "size": 100}}
+
+    @patch("glacier_restore.boto3")
+    def test_standard_storage_class(self, mock_boto3):
+        """HeadObject omits StorageClass for STANDARD — should not crash."""
+        mod.not_on_glacier_count = AtomicInteger()
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {}  # no StorageClass key
+        result = check_status(self._make_to_check())
+        assert result is None
+        assert mod.not_on_glacier_count.value() == 1
+
+    @patch("glacier_restore.boto3")
+    def test_glacier_not_being_restored(self, mock_boto3):
+        mod.restored_count = AtomicInteger()
+        mod.not_on_glacier_count = AtomicInteger()
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {"StorageClass": "GLACIER"}
+        result = check_status(self._make_to_check())
+        assert result is not None
+        assert result["bucket"] == "mybucket"
+
+    @patch("glacier_restore.boto3")
+    def test_glacier_restore_in_progress(self, mock_boto3):
+        mod.restored_count = AtomicInteger()
+        mod.not_on_glacier_count = AtomicInteger()
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {
+            "StorageClass": "GLACIER",
+            "Restore": 'ongoing-request="true"',
+        }
+        result = check_status(self._make_to_check())
+        assert result is None
+        assert mod.restored_count.value() == 0
+
+    @patch("glacier_restore.boto3")
+    def test_glacier_restore_completed(self, mock_boto3):
+        mod.restored_count = AtomicInteger()
+        mod.not_on_glacier_count = AtomicInteger()
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {
+            "StorageClass": "GLACIER",
+            "Restore": 'ongoing-request="false", expiry-date="Mon, 01 Jan 2030 00:00:00 GMT"',
+        }
+        result = check_status(self._make_to_check())
+        assert result is None
+        assert mod.restored_count.value() == 1
+
+    @patch("glacier_restore.boto3")
+    def test_deep_archive_recognized(self, mock_boto3):
+        mod.restored_count = AtomicInteger()
+        mod.not_on_glacier_count = AtomicInteger()
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {"StorageClass": "DEEP_ARCHIVE"}
+        result = check_status(self._make_to_check())
+        # Not being restored, should return the file dict
+        assert result is not None
+
+    @patch("glacier_restore.boto3")
+    def test_intelligent_tiering_recognized(self, mock_boto3):
+        mod.restored_count = AtomicInteger()
+        mod.not_on_glacier_count = AtomicInteger()
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {"StorageClass": "INTELLIGENT_TIERING"}
+        result = check_status(self._make_to_check())
+        # Not being restored, should return the file dict
+        assert result is not None
+        assert mod.not_on_glacier_count.value() == 0
+
+    @patch("glacier_restore.boto3")
+    def test_reduced_redundancy_not_glacier(self, mock_boto3):
+        mod.not_on_glacier_count = AtomicInteger()
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_object.return_value = {"StorageClass": "REDUCED_REDUNDANCY"}
+        result = check_status(self._make_to_check())
+        assert result is None
+        assert mod.not_on_glacier_count.value() == 1


### PR DESCRIPTION
Bug fixes:
  - Fix KeyError crash when HeadObject omits StorageClass for STANDARD objects
  - Fix NameError when module is imported instead of run directly (s_print_lock, restored_count, not_on_glacier_count)
  - Add INTELLIGENT_TIERING to recognized Glacier-restorable storage classes
  - Validate days_to_keep is not None before passing to restore_object API
  - Convert recursive retries to iterative loop in restore() to avoid stack buildup and thread pool starvation
  - Fix "Archvie" typo to "Archive"
  - Fix x != None to x is not None (PEP 8)

  Improvements:
  - Drop Python 2 compatibility — remove __future__ import, replace six.moves.urllib with stdlib urllib.parse, remove six and unused requests from dependencies
  - Change default thread count from 40 to 1
  - Update .gitignore with common Python package patterns
  - Update classifiers for Python 3.7–3.12, add python_requires
  - Add 26 unit tests covering AtomicInteger, get_matching_s3_keys_and_sizes, restore, and check_status
  - Bumped package version to 0.0.5

Changes and commit messages implemented with the assistance of Claude Opus 4.6 (1M context).